### PR TITLE
feat: Add kicad_sym support for enhanced schematic components

### DIFF
--- a/src/convert-kicad-json-to-tscircuit-soup.ts
+++ b/src/convert-kicad-json-to-tscircuit-soup.ts
@@ -1,36 +1,43 @@
-import type { KicadModJson } from "./kicad-zod"
-import type { AnySoupElement } from "@tscircuit/soup"
-import Debug from "debug"
-import { generateArcPath, getArcLength } from "./math/arc-utils"
-import { makePoint } from "./math/make-point"
+import type { KicadModJson, KicadSymJson } from "./kicad-zod";
+import type { AnySoupElement } from "@tscircuit/soup";
+import Debug from "debug";
+import { generateArcPath, getArcLength } from "./math/arc-utils";
+import { makePoint } from "./math/make-point";
+import { convertKicadSymToSchematicInfo } from "./convert-kicad-sym-to-schematic-info";
 
-const debug = Debug("kicad-mod-converter")
+const debug = Debug("kicad-mod-converter");
 
 export const convertKicadLayerToTscircuitLayer = (kicadLayer: string) => {
   switch (kicadLayer) {
     case "F.Cu":
     case "F.Fab":
     case "F.SilkS":
-      return "top"
+      return "top";
     case "B.Cu":
     case "B.Fab":
     case "B.SilkS":
-      return "bottom"
+      return "bottom";
   }
-}
+};
 
 export const convertKicadJsonToTsCircuitSoup = async (
   kicadJson: KicadModJson,
+  kicadSymJson?: KicadSymJson
 ): Promise<AnySoupElement[]> => {
-  const { fp_lines, fp_texts, fp_arcs, pads, properties } = kicadJson
+  const { fp_lines, fp_texts, fp_arcs, pads, properties } = kicadJson;
 
-  const soup: AnySoupElement[] = []
+  const soup: AnySoupElement[] = [];
 
   soup.push({
     type: "source_component",
     source_component_id: "generic_0",
     supplier_part_numbers: {},
-  } as any)
+  } as any);
+
+  // Extract schematic information from kicad_sym if available
+  const schematicInfo = kicadSymJson
+    ? convertKicadSymToSchematicInfo(kicadSymJson)
+    : {};
 
   soup.push({
     type: "schematic_component",
@@ -39,23 +46,27 @@ export const convertKicadJsonToTsCircuitSoup = async (
     center: { x: 0, y: 0 },
     rotation: 0,
     size: { width: 0, height: 0 },
-  } as any)
+    port_arrangement: schematicInfo.schPortArrangement,
+    port_labels: schematicInfo.pinLabels,
+    symbol_name: schematicInfo.symbolName,
+    symbol_display_value: schematicInfo.symbolDisplayValue,
+  } as any);
 
-  let minX = Infinity
-  let maxX = -Infinity
-  let minY = Infinity
-  let maxY = -Infinity
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
   for (const pad of pads) {
-    const x = pad.at[0]
-    const y = -pad.at[1]
-    const w = pad.size[0]
-    const h = pad.size[1]
-    minX = Math.min(minX, x - w / 2)
-    maxX = Math.max(maxX, x + w / 2)
-    minY = Math.min(minY, y - h / 2)
-    maxY = Math.max(maxY, y + h / 2)
+    const x = pad.at[0];
+    const y = -pad.at[1];
+    const w = pad.size[0];
+    const h = pad.size[1];
+    minX = Math.min(minX, x - w / 2);
+    maxX = Math.max(maxX, x + w / 2);
+    minY = Math.min(minY, y - h / 2);
+    maxY = Math.max(maxY, y + h / 2);
   }
-  const pcb_component_id = "pcb_generic_component_0"
+  const pcb_component_id = "pcb_generic_component_0";
 
   soup.push({
     type: "pcb_component",
@@ -66,11 +77,11 @@ export const convertKicadJsonToTsCircuitSoup = async (
     rotation: 0,
     width: isFinite(minX) ? maxX - minX : 0,
     height: isFinite(minY) ? maxY - minY : 0,
-  } as any)
+  } as any);
 
-  let smtpadId = 0
-  let platedHoleId = 0
-  let holeId = 0
+  let smtpadId = 0;
+  let platedHoleId = 0;
+  let holeId = 0;
   for (const pad of pads) {
     if (pad.pad_type === "smd") {
       soup.push({
@@ -84,7 +95,7 @@ export const convertKicadJsonToTsCircuitSoup = async (
         layer: convertKicadLayerToTscircuitLayer(pad.layers?.[0] ?? "F.Cu")!,
         pcb_component_id,
         port_hints: [pad.name],
-      } as any)
+      } as any);
     } else if (pad.pad_type === "thru_hole") {
       if (pad.pad_shape === "circle") {
         soup.push({
@@ -98,7 +109,7 @@ export const convertKicadJsonToTsCircuitSoup = async (
           layers: ["top", "bottom"],
           pcb_component_id,
           port_hints: [pad.name],
-        } as any)
+        } as any);
       } else if (pad.pad_shape === "oval") {
         soup.push({
           type: "pcb_plated_hole",
@@ -112,7 +123,7 @@ export const convertKicadJsonToTsCircuitSoup = async (
           hole_height: pad.drill?.height!,
           layers: ["top", "bottom"],
           pcb_component_id,
-        } as any)
+        } as any);
       }
     } else if (pad.pad_type === "np_thru_hole") {
       soup.push({
@@ -122,18 +133,18 @@ export const convertKicadJsonToTsCircuitSoup = async (
         y: -pad.at[1],
         hole_diameter: pad.drill?.width!,
         pcb_component_id,
-      } as any)
+      } as any);
     }
   }
 
-  let traceId = 0
-  let silkPathId = 0
-  let fabPathId = 0
+  let traceId = 0;
+  let silkPathId = 0;
+  let fabPathId = 0;
   for (const fp_line of fp_lines) {
     const route = [
       { x: fp_line.start[0], y: -fp_line.start[1] },
       { x: fp_line.end[0], y: -fp_line.end[1] },
-    ]
+    ];
     if (fp_line.layer === "F.Cu") {
       soup.push({
         type: "pcb_trace",
@@ -142,7 +153,7 @@ export const convertKicadJsonToTsCircuitSoup = async (
         layer: convertKicadLayerToTscircuitLayer(fp_line.layer)!,
         route,
         thickness: fp_line.stroke.width,
-      } as any)
+      } as any);
     } else if (fp_line.layer === "F.SilkS") {
       soup.push({
         type: "pcb_silkscreen_path",
@@ -151,7 +162,7 @@ export const convertKicadJsonToTsCircuitSoup = async (
         layer: "top",
         route,
         stroke_width: fp_line.stroke.width,
-      } as any)
+      } as any);
     } else if (fp_line.layer === "F.Fab") {
       soup.push({
         type: "pcb_fabrication_note_path",
@@ -161,19 +172,19 @@ export const convertKicadJsonToTsCircuitSoup = async (
         route,
         stroke_width: fp_line.stroke.width,
         port_hints: [],
-      } as any)
+      } as any);
     } else {
-      debug("Unhandled layer for fp_line", fp_line.layer)
+      debug("Unhandled layer for fp_line", fp_line.layer);
     }
   }
 
   for (const fp_arc of fp_arcs) {
-    const start = makePoint(fp_arc.start)
-    const mid = makePoint(fp_arc.mid)
-    const end = makePoint(fp_arc.end)
-    const arcLength = getArcLength(start, mid, end)
+    const start = makePoint(fp_arc.start);
+    const mid = makePoint(fp_arc.mid);
+    const end = makePoint(fp_arc.end);
+    const arcLength = getArcLength(start, mid, end);
 
-    const arcPoints = generateArcPath(start, mid, end, Math.ceil(arcLength))
+    const arcPoints = generateArcPath(start, mid, end, Math.ceil(arcLength));
 
     soup.push({
       type: "pcb_silkscreen_path",
@@ -182,7 +193,7 @@ export const convertKicadJsonToTsCircuitSoup = async (
       pcb_component_id,
       route: arcPoints.map((p) => ({ x: p.x, y: -p.y })),
       stroke_width: fp_arc.stroke.width,
-    } as any)
+    } as any);
   }
 
   for (const fp_text of fp_texts) {
@@ -195,15 +206,15 @@ export const convertKicadJsonToTsCircuitSoup = async (
       anchor_position: { x: fp_text.at[0], y: -fp_text.at[1] },
       anchor_alignment: "center",
       text: fp_text.text,
-    } as any)
+    } as any);
   }
 
-  const refProp = properties.find((prop) => prop.key === "Reference")
-  const valProp = properties.find((prop) => prop.key === "Value")
-  const propFabTexts = [refProp, valProp].filter((p) => p && Boolean(p.val))
+  const refProp = properties.find((prop) => prop.key === "Reference");
+  const valProp = properties.find((prop) => prop.key === "Value");
+  const propFabTexts = [refProp, valProp].filter((p) => p && Boolean(p.val));
   for (const propFab of propFabTexts) {
-    const at = propFab!.attributes.at
-    if (!at) continue
+    const at = propFab!.attributes.at;
+    if (!at) continue;
     soup.push({
       type: "pcb_silkscreen_text",
       layer: "top",
@@ -213,8 +224,8 @@ export const convertKicadJsonToTsCircuitSoup = async (
       anchor_position: { x: at[0], y: -at[1] },
       anchor_alignment: "center",
       text: propFab!.val,
-    } as any)
+    } as any);
   }
 
-  return soup as any
-}
+  return soup as any;
+};

--- a/src/convert-kicad-sym-to-schematic-info.ts
+++ b/src/convert-kicad-sym-to-schematic-info.ts
@@ -1,0 +1,287 @@
+import type { KicadSymJson, Symbol, SymbolPin } from "./kicad-zod"
+import Debug from "debug"
+
+const debug = Debug("kicad-sym-to-schematic")
+
+export interface SchematicPortArrangementBySides {
+  left_side?: {
+    pins: number[]
+    direction?: "top-to-bottom" | "bottom-to-top"
+  }
+  right_side?: {
+    pins: number[]
+    direction?: "top-to-bottom" | "bottom-to-top"
+  }
+  top_side?: {
+    pins: number[]
+    direction?: "left-to-right" | "right-to-left"
+  }
+  bottom_side?: {
+    pins: number[]
+    direction?: "left-to-right" | "right-to-left"
+  }
+}
+
+export interface SchematicPortArrangementBySize {
+  left_size: number
+  right_size: number
+  top_size?: number
+  bottom_size?: number
+}
+
+export type SchematicPortArrangement = SchematicPortArrangementBySides | SchematicPortArrangementBySize
+
+export interface SchematicInfo {
+  schPortArrangement?: SchematicPortArrangement
+  pinLabels?: Record<string, string>
+  symbolName?: string
+  symbolDisplayValue?: string
+}
+
+/**
+ * Converts a parsed kicad_sym file into schematic information
+ * including port arrangement and pin labels
+ */
+export const convertKicadSymToSchematicInfo = (kicadSymJson: KicadSymJson): SchematicInfo => {
+  // Find the main symbol (usually the first one or the one without unit suffix)
+  const mainSymbol = findMainSymbol(kicadSymJson.symbols)
+  
+  if (!mainSymbol) {
+    debug("No main symbol found")
+    return {}
+  }
+
+  // Collect all pins from the main symbol and its units
+  const allPins = collectAllPins(mainSymbol)
+  
+  if (allPins.length === 0) {
+    debug("No pins found in symbol")
+    return {}
+  }
+
+  // Generate pin labels from pin names and numbers
+  const pinLabels = generatePinLabels(allPins)
+  
+  // Generate port arrangement based on pin positions
+  const schPortArrangement = generatePortArrangement(allPins)
+  
+  // Extract symbol information
+  const symbolName = extractSymbolName(mainSymbol)
+  const symbolDisplayValue = extractSymbolDisplayValue(mainSymbol)
+
+  return {
+    schPortArrangement,
+    pinLabels,
+    symbolName,
+    symbolDisplayValue,
+  }
+}
+
+/**
+ * Find the main symbol from the list of symbols
+ * The main symbol is typically the one that doesn't have a unit suffix (_0_0, _1_1, etc.)
+ * or the first symbol if all have unit suffixes
+ */
+const findMainSymbol = (symbols: Symbol[]): Symbol | null => {
+  if (symbols.length === 0) return null
+  
+  // Look for a symbol without unit suffix first
+  const mainSymbol = symbols.find(symbol => !symbol.name.includes("_"))
+  if (mainSymbol) return mainSymbol
+  
+  // If all symbols have unit suffixes, find the base symbol (_0_0)
+  const baseSymbol = symbols.find(symbol => symbol.name.endsWith("_0_0"))
+  if (baseSymbol) return baseSymbol
+  
+  // Fallback to the first symbol
+  return symbols[0]
+}
+
+/**
+ * Collect all pins from a symbol and its units
+ */
+const collectAllPins = (symbol: Symbol): SymbolPin[] => {
+  const pins: SymbolPin[] = [...symbol.pins]
+  
+  // Add pins from units
+  if (symbol.units) {
+    for (const unit of symbol.units) {
+      pins.push(...collectAllPins(unit))
+    }
+  }
+  
+  return pins
+}
+
+/**
+ * Generate pin labels mapping from pin numbers to pin names
+ */
+const generatePinLabels = (pins: SymbolPin[]): Record<string, string> => {
+  const pinLabels: Record<string, string> = {}
+  
+  for (const pin of pins) {
+    if (pin.number && pin.name) {
+      pinLabels[pin.number] = pin.name
+    }
+  }
+  
+  return pinLabels
+}
+
+/**
+ * Generate port arrangement based on pin positions
+ * This analyzes the pin positions to determine which side of the symbol they're on
+ */
+const generatePortArrangement = (pins: SymbolPin[]): SchematicPortArrangement => {
+  if (pins.length === 0) {
+    return { left_size: 0, right_size: 0 }
+  }
+
+  // Analyze pin positions to determine sides
+  const pinsBySide = categorizePinsBySide(pins)
+  
+  // If we have clear side categorization, use sides-based arrangement
+  if (hasMultipleSides(pinsBySide)) {
+    return generateSidesArrangement(pinsBySide)
+  }
+  
+  // Otherwise, use size-based arrangement
+  return generateSizeArrangement(pins)
+}
+
+interface PinsBySide {
+  left: SymbolPin[]
+  right: SymbolPin[]
+  top: SymbolPin[]
+  bottom: SymbolPin[]
+}
+
+/**
+ * Categorize pins by which side of the symbol they're on
+ * based on their position and rotation
+ */
+const categorizePinsBySide = (pins: SymbolPin[]): PinsBySide => {
+  const sides: PinsBySide = {
+    left: [],
+    right: [],
+    top: [],
+    bottom: []
+  }
+  
+  for (const pin of pins) {
+    const [x, y, rotation = 0] = pin.at
+    
+    // Determine side based on rotation (pin direction)
+    // In KiCad, pin rotation indicates the direction the pin points
+    // 0° = right, 90° = up, 180° = left, 270° = down
+    const normalizedRotation = ((rotation % 360) + 360) % 360
+    
+    if (normalizedRotation === 0) {
+      // Pin points right, so it's on the left side of the symbol
+      sides.left.push(pin)
+    } else if (normalizedRotation === 90) {
+      // Pin points up, so it's on the bottom side of the symbol
+      sides.bottom.push(pin)
+    } else if (normalizedRotation === 180) {
+      // Pin points left, so it's on the right side of the symbol
+      sides.right.push(pin)
+    } else if (normalizedRotation === 270) {
+      // Pin points down, so it's on the top side of the symbol
+      sides.top.push(pin)
+    } else {
+      // For non-standard rotations, use position to guess
+      // This is a fallback and may not be accurate
+      if (x < 0) sides.left.push(pin)
+      else if (x > 0) sides.right.push(pin)
+      else if (y > 0) sides.top.push(pin)
+      else sides.bottom.push(pin)
+    }
+  }
+  
+  return sides
+}
+
+/**
+ * Check if pins are distributed across multiple sides
+ */
+const hasMultipleSides = (pinsBySide: PinsBySide): boolean => {
+  const sidesWithPins = [
+    pinsBySide.left.length > 0,
+    pinsBySide.right.length > 0,
+    pinsBySide.top.length > 0,
+    pinsBySide.bottom.length > 0
+  ].filter(Boolean).length
+  
+  return sidesWithPins > 1
+}
+
+/**
+ * Generate sides-based port arrangement
+ */
+const generateSidesArrangement = (pinsBySide: PinsBySide): SchematicPortArrangementBySides => {
+  const arrangement: SchematicPortArrangementBySides = {}
+  
+  if (pinsBySide.left.length > 0) {
+    arrangement.left_side = {
+      pins: pinsBySide.left.map(pin => Number.parseInt(pin.number) || 0).filter(n => n > 0),
+      direction: "top-to-bottom"
+    }
+  }
+  
+  if (pinsBySide.right.length > 0) {
+    arrangement.right_side = {
+      pins: pinsBySide.right.map(pin => Number.parseInt(pin.number) || 0).filter(n => n > 0),
+      direction: "top-to-bottom"
+    }
+  }
+  
+  if (pinsBySide.top.length > 0) {
+    arrangement.top_side = {
+      pins: pinsBySide.top.map(pin => Number.parseInt(pin.number) || 0).filter(n => n > 0),
+      direction: "left-to-right"
+    }
+  }
+  
+  if (pinsBySide.bottom.length > 0) {
+    arrangement.bottom_side = {
+      pins: pinsBySide.bottom.map(pin => Number.parseInt(pin.number) || 0).filter(n => n > 0),
+      direction: "left-to-right"
+    }
+  }
+  
+  return arrangement
+}
+
+/**
+ * Generate size-based port arrangement
+ * This is a fallback when pins aren't clearly on different sides
+ */
+const generateSizeArrangement = (pins: SymbolPin[]): SchematicPortArrangementBySize => {
+  const totalPins = pins.length
+  
+  // Simple heuristic: distribute pins evenly between left and right
+  // For more complex symbols, this could be improved
+  const leftSize = Math.ceil(totalPins / 2)
+  const rightSize = totalPins - leftSize
+  
+  return {
+    left_size: leftSize,
+    right_size: rightSize
+  }
+}
+
+/**
+ * Extract symbol name from properties
+ */
+const extractSymbolName = (symbol: Symbol): string | undefined => {
+  const valueProperty = symbol.properties.find(prop => prop.key === "Value")
+  return valueProperty?.value || symbol.name
+}
+
+/**
+ * Extract symbol display value from properties
+ */
+const extractSymbolDisplayValue = (symbol: Symbol): string | undefined => {
+  const valueProperty = symbol.properties.find(prop => prop.key === "Value")
+  return valueProperty?.value
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
-export { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
-export { parseKicadModToCircuitJson } from "./parse-kicad-mod-to-circuit-json"
-export { convertKicadJsonToTsCircuitSoup } from "./convert-kicad-json-to-tscircuit-soup"
+export { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json";
+export { parseKicadModToCircuitJson } from "./parse-kicad-mod-to-circuit-json";
+export { parseKicadSymToKicadJson } from "./parse-kicad-sym-to-kicad-json";
+export { parseKicadSymToCircuitJson } from "./parse-kicad-sym-to-circuit-json";
+export { parseKicadFilesToCircuitJson } from "./parse-kicad-files-to-circuit-json";
+export { convertKicadJsonToTsCircuitSoup } from "./convert-kicad-json-to-tscircuit-soup";
+export { convertKicadSymToSchematicInfo } from "./convert-kicad-sym-to-schematic-info";

--- a/src/kicad-zod.ts
+++ b/src/kicad-zod.ts
@@ -1,10 +1,10 @@
-import { z } from "zod"
+import { z } from "zod";
 
-export const point2 = z.tuple([z.coerce.number(), z.coerce.number()])
-export const point3 = z.tuple([z.number(), z.number(), z.number()])
-export const point = z.union([point2, point3])
+export const point2 = z.tuple([z.coerce.number(), z.coerce.number()]);
+export const point3 = z.tuple([z.number(), z.number(), z.number()]);
+export const point = z.union([point2, point3]);
 
-type MakeRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>
+type MakeRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
 
 export const attributes_def = z
   .object({
@@ -14,20 +14,20 @@ export const attributes_def = z
     roundrect_rratio: z.number(),
     uuid: z.string(),
   })
-  .partial()
+  .partial();
 
 export const property_def = z.object({
   key: z.string(),
   val: z.string(),
   attributes: attributes_def,
-})
+});
 
 const drill_def = z.object({
   oval: z.boolean().default(false),
   width: z.number().optional(),
   height: z.number().optional(),
   offset: point2.optional(),
-})
+});
 
 export const pad_def = z.object({
   name: z.string(),
@@ -46,16 +46,16 @@ export const pad_def = z.object({
     .union([z.number(), z.array(z.any()), drill_def])
     .transform((a) => {
       if (typeof a === "number") {
-        return { oval: false, width: a, height: a }
+        return { oval: false, width: a, height: a };
       }
-      if ("oval" in a) return a
+      if ("oval" in a) return a;
       if (a.length === 2) {
         return {
           oval: false,
           width: Number.parseFloat(a[0]),
           height: Number.parseFloat(a[0]),
           offset: point2.parse(a[1].slice(1)),
-        }
+        };
       }
       if (a.length === 3 || a.length === 4) {
         return {
@@ -63,9 +63,9 @@ export const pad_def = z.object({
           width: Number.parseFloat(a[1] as string),
           height: Number.parseFloat(a[2] as string),
           offset: a[3] ? point2.parse(a[3].slice(1)) : undefined,
-        }
+        };
       }
-      return a
+      return a;
     })
     .pipe(drill_def)
     .optional(),
@@ -85,7 +85,7 @@ export const pad_def = z.object({
   thermal_width: z.number().optional(),
   thermal_gap: z.number().optional(),
   uuid: z.string().optional(),
-})
+});
 
 export const effects_def = z
   .object({
@@ -94,7 +94,7 @@ export const effects_def = z
       thickness: z.number().optional(),
     }),
   })
-  .partial()
+  .partial();
 
 export const fp_text_def = z.object({
   fp_text_type: z.literal("user"),
@@ -103,7 +103,7 @@ export const fp_text_def = z.object({
   layer: z.string(),
   uuid: z.string().optional(),
   effects: effects_def.partial(),
-})
+});
 
 export const fp_arc_def = z.object({
   start: point2,
@@ -115,7 +115,7 @@ export const fp_arc_def = z.object({
   }),
   layer: z.string(),
   uuid: z.string().optional(),
-})
+});
 
 export const fp_line = z
   .object({
@@ -137,8 +137,8 @@ export const fp_line = z
       ...data,
       width: undefined,
       stroke: data.stroke ?? { width: data.width },
-    } as MakeRequired<Omit<typeof data, "width">, "stroke">
-  })
+    } as MakeRequired<Omit<typeof data, "width">, "stroke">;
+  });
 
 export const kicad_mod_json_def = z.object({
   footprint_name: z.string(),
@@ -153,16 +153,149 @@ export const kicad_mod_json_def = z.object({
   fp_texts: z.array(fp_text_def),
   fp_arcs: z.array(fp_arc_def),
   pads: z.array(pad_def),
-})
+});
 
-export type Point2 = z.infer<typeof point2>
-export type Point3 = z.infer<typeof point3>
-export type Point = z.infer<typeof point>
-export type Attributes = z.infer<typeof attributes_def>
-export type Property = z.infer<typeof property_def>
-export type Pad = z.infer<typeof pad_def>
-export type EffectsObj = z.infer<typeof effects_def>
-export type FpText = z.infer<typeof fp_text_def>
-export type FpLine = z.infer<typeof fp_line>
-export type FpArc = z.infer<typeof fp_arc_def>
-export type KicadModJson = z.infer<typeof kicad_mod_json_def>
+// KiCad Symbol (.kicad_sym) definitions
+export const pin_electrical_type = z.enum([
+  "input",
+  "output",
+  "bidirectional",
+  "tri_state",
+  "passive",
+  "free",
+  "unspecified",
+  "power_in",
+  "power_out",
+  "open_collector",
+  "open_emitter",
+  "no_connect",
+]);
+
+export const pin_graphic_style = z.enum([
+  "line",
+  "inverted",
+  "clock",
+  "inverted_clock",
+  "input_low",
+  "clock_low",
+  "output_low",
+  "edge_clock_high",
+  "non_logic",
+]);
+
+export const symbol_pin_def = z.object({
+  electrical_type: pin_electrical_type,
+  graphic_style: pin_graphic_style,
+  at: point,
+  length: z.number(),
+  name: z.string(),
+  number: z.string(),
+  name_effects: effects_def.optional(),
+  number_effects: effects_def.optional(),
+});
+
+export const symbol_property_def = z.object({
+  key: z.string(),
+  value: z.string(),
+  id: z.number(),
+  at: point,
+  effects: effects_def.optional(),
+});
+
+export const stroke_def = z.object({
+  width: z.number(),
+  type: z
+    .enum(["dash", "dash_dot", "dash_dot_dot", "dot", "default", "solid"])
+    .optional(),
+  color: z.tuple([z.number(), z.number(), z.number(), z.number()]).optional(),
+});
+
+export const fill_def = z.object({
+  type: z.enum(["none", "outline", "background"]),
+});
+
+export const symbol_arc_def = z.object({
+  start: point2,
+  mid: point2,
+  end: point2,
+  stroke: stroke_def,
+  fill: fill_def.optional(),
+});
+
+export const symbol_circle_def = z.object({
+  center: point2,
+  radius: z.number(),
+  stroke: stroke_def,
+  fill: fill_def.optional(),
+});
+
+export const symbol_rectangle_def = z.object({
+  start: point2,
+  end: point2,
+  stroke: stroke_def,
+  fill: fill_def.optional(),
+});
+
+export const symbol_polyline_def = z.object({
+  points: z.array(point2),
+  stroke: stroke_def,
+  fill: fill_def.optional(),
+});
+
+export const symbol_text_def = z.object({
+  text: z.string(),
+  at: point,
+  effects: effects_def.optional(),
+});
+
+export const symbol_def = z.object({
+  name: z.string(),
+  extends: z.string().optional(),
+  pin_numbers_hide: z.boolean().optional(),
+  pin_names_hide: z.boolean().optional(),
+  pin_names_offset: z.number().optional(),
+  in_bom: z.boolean(),
+  on_board: z.boolean(),
+  properties: z.array(symbol_property_def),
+  pins: z.array(symbol_pin_def),
+  arcs: z.array(symbol_arc_def).optional(),
+  circles: z.array(symbol_circle_def).optional(),
+  rectangles: z.array(symbol_rectangle_def).optional(),
+  polylines: z.array(symbol_polyline_def).optional(),
+  texts: z.array(symbol_text_def).optional(),
+  units: z.array(z.lazy(() => symbol_def)).optional(),
+  unit_name: z.string().optional(),
+});
+
+export const kicad_sym_json_def = z.object({
+  version: z.string(),
+  generator: z.string(),
+  symbols: z.array(symbol_def),
+});
+
+export type Point2 = z.infer<typeof point2>;
+export type Point3 = z.infer<typeof point3>;
+export type Point = z.infer<typeof point>;
+export type Attributes = z.infer<typeof attributes_def>;
+export type Property = z.infer<typeof property_def>;
+export type Pad = z.infer<typeof pad_def>;
+export type EffectsObj = z.infer<typeof effects_def>;
+export type FpText = z.infer<typeof fp_text_def>;
+export type FpLine = z.infer<typeof fp_line>;
+export type FpArc = z.infer<typeof fp_arc_def>;
+export type KicadModJson = z.infer<typeof kicad_mod_json_def>;
+
+// KiCad Symbol types
+export type PinElectricalType = z.infer<typeof pin_electrical_type>;
+export type PinGraphicStyle = z.infer<typeof pin_graphic_style>;
+export type SymbolPin = z.infer<typeof symbol_pin_def>;
+export type SymbolProperty = z.infer<typeof symbol_property_def>;
+export type StrokeDef = z.infer<typeof stroke_def>;
+export type FillDef = z.infer<typeof fill_def>;
+export type SymbolArc = z.infer<typeof symbol_arc_def>;
+export type SymbolCircle = z.infer<typeof symbol_circle_def>;
+export type SymbolRectangle = z.infer<typeof symbol_rectangle_def>;
+export type SymbolPolyline = z.infer<typeof symbol_polyline_def>;
+export type SymbolText = z.infer<typeof symbol_text_def>;
+export type Symbol = z.infer<typeof symbol_def>;
+export type KicadSymJson = z.infer<typeof kicad_sym_json_def>;

--- a/src/parse-kicad-files-to-circuit-json.ts
+++ b/src/parse-kicad-files-to-circuit-json.ts
@@ -1,0 +1,40 @@
+import type { AnyCircuitElement } from "circuit-json"
+import { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
+import { parseKicadSymToKicadJson } from "./parse-kicad-sym-to-kicad-json"
+import { convertKicadJsonToTsCircuitSoup } from "./convert-kicad-json-to-tscircuit-soup"
+
+export interface KicadFiles {
+  kicad_mod?: string
+  kicad_sym?: string
+}
+
+/**
+ * Parse both kicad_mod and kicad_sym files and convert them to circuit JSON
+ * The kicad_mod provides the PCB footprint information
+ * The kicad_sym provides the schematic symbol information (port arrangement, pin labels)
+ */
+export const parseKicadFilesToCircuitJson = async (
+  files: KicadFiles,
+): Promise<AnyCircuitElement[]> => {
+  if (!files.kicad_mod) {
+    throw new Error("kicad_mod file is required")
+  }
+
+  // Parse the kicad_mod file
+  const kicadModJson = parseKicadModToKicadJson(files.kicad_mod)
+
+  // Parse the kicad_sym file if provided
+  let kicadSymJson = undefined
+  if (files.kicad_sym) {
+    try {
+      kicadSymJson = parseKicadSymToKicadJson(files.kicad_sym)
+    } catch (error) {
+      console.warn("Failed to parse kicad_sym file:", error)
+      // Continue without symbol information
+    }
+  }
+
+  // Convert to circuit JSON with enhanced schematic information
+  const circuitJson = await convertKicadJsonToTsCircuitSoup(kicadModJson, kicadSymJson)
+  return circuitJson as any
+}

--- a/src/parse-kicad-sym-to-circuit-json.ts
+++ b/src/parse-kicad-sym-to-circuit-json.ts
@@ -1,0 +1,13 @@
+import type { AnyCircuitElement } from "circuit-json"
+import { parseKicadSymToKicadJson } from "./parse-kicad-sym-to-kicad-json"
+
+export const parseKicadSymToCircuitJson = async (
+  kicadSym: string,
+): Promise<AnyCircuitElement[]> => {
+  const kicadSymJson = parseKicadSymToKicadJson(kicadSym)
+
+  // For now, just return an empty array since kicad_sym files don't directly
+  // translate to circuit elements - they provide schematic information
+  // that enhances the schematic_component created from kicad_mod files
+  return []
+}

--- a/src/parse-kicad-sym-to-kicad-json.ts
+++ b/src/parse-kicad-sym-to-kicad-json.ts
@@ -1,0 +1,297 @@
+import parseSExpression from "s-expression"
+import {
+  kicad_sym_json_def,
+  symbol_def,
+  symbol_pin_def,
+  symbol_property_def,
+  effects_def,
+  stroke_def,
+  fill_def,
+  type KicadSymJson,
+  type Symbol,
+  type SymbolPin,
+  type SymbolProperty,
+} from "./kicad-zod"
+import { formatAttr, getAttr } from "./get-attr"
+import Debug from "debug"
+
+const debug = Debug("kicad-sym-converter")
+
+export const parseKicadSymToKicadJson = (fileContent: string): KicadSymJson => {
+  const kicadSExpr = parseSExpression(fileContent)
+
+  // The root should be (kicad_symbol_lib ...)
+  if (kicadSExpr[0] !== "kicad_symbol_lib") {
+    throw new Error("Invalid kicad_sym file: missing kicad_symbol_lib root")
+  }
+
+  let version = ""
+  let generator = ""
+  const symbols: Symbol[] = []
+
+  // Parse header information and symbols
+  for (const row of kicadSExpr.slice(1)) {
+    if (Array.isArray(row)) {
+      const token = row[0]?.valueOf()
+      
+      if (token === "version") {
+        version = row[1]?.valueOf() || ""
+      } else if (token === "generator") {
+        generator = row[1]?.valueOf() || ""
+      } else if (token === "symbol") {
+        const symbol = parseSymbol(row)
+        if (symbol) {
+          symbols.push(symbol)
+        }
+      }
+    }
+  }
+
+  return kicad_sym_json_def.parse({
+    version,
+    generator,
+    symbols,
+  })
+}
+
+const parseSymbol = (symbolRow: any[]): Symbol | null => {
+  try {
+    const name = symbolRow[1]?.valueOf() || ""
+
+    let extends: string | undefined
+    let pin_numbers_hide = false
+    let pin_names_hide = false
+    let pin_names_offset: number | undefined
+    let in_bom = true
+    let on_board = true
+    const properties: SymbolProperty[] = []
+    const pins: SymbolPin[] = []
+    const units: Symbol[] = []
+    let unit_name: string | undefined
+
+    // Parse symbol attributes
+    for (const attr of symbolRow.slice(2)) {
+      if (!Array.isArray(attr)) continue
+
+      const token = attr[0]?.valueOf()
+
+      switch (token) {
+        case "extends":
+          extends = attr[1]?.valueOf()
+          break
+        case "pin_numbers":
+          if (attr[1]?.valueOf() === "hide") {
+            pin_numbers_hide = true
+          }
+          break
+        case "pin_names":
+          // Can have (pin_names hide) or (pin_names (offset 0.508) hide)
+          for (const subAttr of attr.slice(1)) {
+            if (subAttr === "hide") {
+              pin_names_hide = true
+            } else if (Array.isArray(subAttr) && subAttr[0] === "offset") {
+              pin_names_offset = Number.parseFloat(subAttr[1]?.valueOf() || "0")
+            }
+          }
+          break
+        case "in_bom":
+          in_bom = attr[1]?.valueOf() === "yes"
+          break
+        case "on_board":
+          on_board = attr[1]?.valueOf() === "yes"
+          break
+        case "property":
+          const property = parseProperty(attr)
+          if (property) {
+            properties.push(property)
+          }
+          break
+        case "pin":
+          const pin = parsePin(attr)
+          if (pin) {
+            pins.push(pin)
+          }
+          break
+        case "symbol":
+          const unit = parseSymbol(attr)
+          if (unit) {
+            units.push(unit)
+          }
+          break
+        case "unit_name":
+          unit_name = attr[1]?.valueOf()
+          break
+        // Skip graphic items for now - we'll focus on pins for schematic view
+        case "arc":
+        case "circle":
+        case "rectangle":
+        case "polyline":
+        case "text":
+          // TODO: Parse graphic items if needed for symbol display
+          break
+      }
+    }
+
+    return symbol_def.parse({
+      name,
+      extends,
+      pin_numbers_hide: pin_numbers_hide || undefined,
+      pin_names_hide: pin_names_hide || undefined,
+      pin_names_offset,
+      in_bom,
+      on_board,
+      properties,
+      pins,
+      units: units.length > 0 ? units : undefined,
+      unit_name,
+    })
+  } catch (error) {
+    debug(`Error parsing symbol: ${error}`)
+    return null
+  }
+}
+
+const parseProperty = (propertyRow: any[]): SymbolProperty | null => {
+  try {
+    const key = propertyRow[1]?.valueOf() || ""
+    const value = propertyRow[2]?.valueOf() || ""
+    
+    let id = 0
+    let at = [0, 0] as [number, number]
+    let effects = undefined
+
+    for (const attr of propertyRow.slice(3)) {
+      if (!Array.isArray(attr)) continue
+      
+      const token = attr[0]?.valueOf()
+      
+      switch (token) {
+        case "id":
+          id = Number.parseInt(attr[1]?.valueOf() || "0")
+          break
+        case "at":
+          at = [
+            Number.parseFloat(attr[1]?.valueOf() || "0"),
+            Number.parseFloat(attr[2]?.valueOf() || "0")
+          ]
+          break
+        case "effects":
+          effects = parseEffects(attr)
+          break
+      }
+    }
+
+    return symbol_property_def.parse({
+      key,
+      value,
+      id,
+      at,
+      effects,
+    })
+  } catch (error) {
+    debug(`Error parsing property: ${error}`)
+    return null
+  }
+}
+
+const parsePin = (pinRow: any[]): SymbolPin | null => {
+  try {
+    const electrical_type = pinRow[1]?.valueOf() || "passive"
+    const graphic_style = pinRow[2]?.valueOf() || "line"
+    
+    let at = [0, 0] as [number, number]
+    let length = 2.54
+    let name = ""
+    let number = ""
+    let name_effects = undefined
+    let number_effects = undefined
+
+    for (const attr of pinRow.slice(3)) {
+      if (!Array.isArray(attr)) continue
+      
+      const token = attr[0]?.valueOf()
+      
+      switch (token) {
+        case "at":
+          at = [
+            Number.parseFloat(attr[1]?.valueOf() || "0"),
+            Number.parseFloat(attr[2]?.valueOf() || "0")
+          ]
+          if (attr[3]) {
+            at.push(Number.parseFloat(attr[3]?.valueOf() || "0"))
+          }
+          break
+        case "length":
+          length = Number.parseFloat(attr[1]?.valueOf() || "2.54")
+          break
+        case "name":
+          name = attr[1]?.valueOf() || ""
+          if (attr[2]) {
+            name_effects = parseEffects(attr[2])
+          }
+          break
+        case "number":
+          number = attr[1]?.valueOf() || ""
+          if (attr[2]) {
+            number_effects = parseEffects(attr[2])
+          }
+          break
+      }
+    }
+
+    return symbol_pin_def.parse({
+      electrical_type,
+      graphic_style,
+      at,
+      length,
+      name,
+      number,
+      name_effects,
+      number_effects,
+    })
+  } catch (error) {
+    debug(`Error parsing pin: ${error}`)
+    return null
+  }
+}
+
+const parseEffects = (effectsRow: any[]): any => {
+  try {
+    const effectsObj: any = {}
+    
+    for (const attr of effectsRow.slice(1)) {
+      if (!Array.isArray(attr)) continue
+      
+      const token = attr[0]?.valueOf()
+      
+      if (token === "font") {
+        const fontObj: any = {}
+        for (const fontAttr of attr.slice(1)) {
+          if (Array.isArray(fontAttr)) {
+            const fontToken = fontAttr[0]?.valueOf()
+            if (fontToken === "size") {
+              fontObj.size = [
+                Number.parseFloat(fontAttr[1]?.valueOf() || "1.27"),
+                Number.parseFloat(fontAttr[2]?.valueOf() || "1.27")
+              ]
+            } else if (fontToken === "thickness") {
+              fontObj.thickness = Number.parseFloat(fontAttr[1]?.valueOf() || "0")
+            }
+          } else if (fontAttr === "bold") {
+            fontObj.bold = true
+          } else if (fontAttr === "italic") {
+            fontObj.italic = true
+          }
+        }
+        effectsObj.font = fontObj
+      } else if (token === "hide") {
+        effectsObj.hide = true
+      }
+    }
+
+    return effects_def.parse(effectsObj)
+  } catch (error) {
+    debug(`Error parsing effects: ${error}`)
+    return undefined
+  }
+}

--- a/src/site/App.tsx
+++ b/src/site/App.tsx
@@ -1,97 +1,102 @@
-import { useCallback, useState, useRef } from "react"
-import { useStore } from "./use-store"
-import { Download, FileSearch } from "lucide-react"
-import { parseKicadModToCircuitJson } from "src/parse-kicad-mod-to-circuit-json"
-import { CircuitJsonPreview } from "@tscircuit/runframe"
-import { convertCircuitJsonToTscircuit } from "circuit-json-to-tscircuit"
-import { createSnippetUrl } from "@tscircuit/create-snippet-url"
+import { useCallback, useState, useRef } from "react";
+import { useStore } from "./use-store";
+import { Download, FileSearch } from "lucide-react";
+import { parseKicadModToCircuitJson } from "src/parse-kicad-mod-to-circuit-json";
+import { parseKicadFilesToCircuitJson } from "src/parse-kicad-files-to-circuit-json";
+import { CircuitJsonPreview } from "@tscircuit/runframe";
+import { convertCircuitJsonToTscircuit } from "circuit-json-to-tscircuit";
+import { createSnippetUrl } from "@tscircuit/create-snippet-url";
 
 export const App = () => {
-  const [error, setError] = useState<string | null>(null)
-  const filesAdded = useStore((s) => s.filesAdded)
-  const addFile = useStore((s) => s.addFile)
-  const reset = useStore((s) => s.reset)
-  const updateCircuitJson = useStore((s) => s.updateCircuitJson)
-  const circuitJson = useStore((s) => s.circuitJson)
-  const updateTscircuitCode = useStore((s) => s.updateTscircuitCode)
-  const tscircuitCode = useStore((s) => s.tscircuitCode)
-  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const [error, setError] = useState<string | null>(null);
+  const filesAdded = useStore((s) => s.filesAdded);
+  const addFile = useStore((s) => s.addFile);
+  const reset = useStore((s) => s.reset);
+  const updateCircuitJson = useStore((s) => s.updateCircuitJson);
+  const circuitJson = useStore((s) => s.circuitJson);
+  const updateTscircuitCode = useStore((s) => s.updateTscircuitCode);
+  const tscircuitCode = useStore((s) => s.tscircuitCode);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   const handleProcessAndViewFiles = useCallback(async () => {
     if (!filesAdded.kicad_mod) {
-      setError("No KiCad Mod file added")
-      return
+      setError("No KiCad Mod file added");
+      return;
     }
-    setError(null)
-    let circuitJson: any
+    setError(null);
+    let circuitJson: any;
     try {
-      circuitJson = await parseKicadModToCircuitJson(filesAdded.kicad_mod)
-      updateCircuitJson(circuitJson as any)
+      // Use the new combined parser that handles both kicad_mod and kicad_sym
+      circuitJson = await parseKicadFilesToCircuitJson({
+        kicad_mod: filesAdded.kicad_mod,
+        kicad_sym: filesAdded.kicad_sym,
+      });
+      updateCircuitJson(circuitJson as any);
     } catch (err: any) {
-      setError(`Error parsing KiCad Mod file: ${err.toString()}`)
-      return
+      setError(`Error parsing KiCad files: ${err.toString()}`);
+      return;
     }
 
     try {
       // Now we convert the circuit json to tscircuit
       const tscircuit = convertCircuitJsonToTscircuit(circuitJson, {
         componentName: "MyComponent",
-      })
-      updateTscircuitCode(tscircuit)
+      });
+      updateTscircuitCode(tscircuit);
     } catch (err: any) {
       setError(
-        `Error converting circuit json to tscircuit: ${err.toString()}\n\n${err.stack}`,
-      )
+        `Error converting circuit json to tscircuit: ${err.toString()}\n\n${err.stack}`
+      );
     }
-  }, [filesAdded])
+  }, [filesAdded]);
 
   const addDroppedFile = useCallback(
     (fileName: string, file: string) => {
-      setError(null)
+      setError(null);
       if (
         fileName.endsWith(".kicad_mod") ||
         fileName.endsWith(".kicad_mod.txt") ||
         file.trim().startsWith("(footprint")
       ) {
-        addFile("kicad_mod", file)
+        addFile("kicad_mod", file);
       } else if (fileName.endsWith(".kicad_sym")) {
-        addFile("kicad_sym", file)
+        addFile("kicad_sym", file);
       } else {
-        setError("Unsupported file type")
+        setError("Unsupported file type");
       }
     },
-    [addFile],
-  )
+    [addFile]
+  );
 
   const handleDrop = useCallback(
     (e: React.DragEvent) => {
-      e.preventDefault()
+      e.preventDefault();
       // biome-ignore lint/complexity/noForEach: <explanation>
       Array.from(e.dataTransfer.files).forEach((file) => {
-        const reader = new FileReader()
+        const reader = new FileReader();
         reader.onload = (e) =>
-          addDroppedFile(file.name, e.target?.result as string)
-        reader.readAsText(file)
-      })
+          addDroppedFile(file.name, e.target?.result as string);
+        reader.readAsText(file);
+      });
     },
-    [addDroppedFile],
-  )
+    [addDroppedFile]
+  );
 
   const handlePaste = useCallback(
     (e: React.ClipboardEvent) => {
-      const content = e.clipboardData.getData("text")
-      if (!content) return
+      const content = e.clipboardData.getData("text");
+      if (!content) return;
       if (content.trim().startsWith("(footprint")) {
-        addDroppedFile("kicad_mod", content)
+        addDroppedFile("kicad_mod", content);
       } else if (content.trim().startsWith("(symbol")) {
-        addDroppedFile("kicad_sym", content)
+        addDroppedFile("kicad_sym", content);
       } else {
-        setError("Unsupported file type (file an issue if we're wrong)")
+        setError("Unsupported file type (file an issue if we're wrong)");
       }
     },
-    [addDroppedFile],
-  )
+    [addDroppedFile]
+  );
 
   return (
     <div
@@ -108,14 +113,14 @@ export const App = () => {
         accept=".kicad_mod,.kicad_mod.txt,.kicad_sym,.txt"
         style={{ display: "none" }}
         onChange={(e) => {
-          const file = e.target.files?.[0]
-          if (!file) return
-          const reader = new FileReader()
+          const file = e.target.files?.[0];
+          if (!file) return;
+          const reader = new FileReader();
           reader.onload = (ev) => {
-            addDroppedFile(file.name, ev.target?.result as string)
-          }
-          reader.readAsText(file)
-          e.target.value = ""
+            addDroppedFile(file.name, ev.target?.result as string);
+          };
+          reader.readAsText(file);
+          e.target.value = "";
         }}
       />
       <div className="flex flex-col text-center">
@@ -159,8 +164,8 @@ export const App = () => {
                 type="button"
                 className="bg-gray-700 inline-flex items-center text-white p-2 rounded-md"
                 onClick={() => {
-                  setError(null)
-                  reset()
+                  setError(null);
+                  reset();
                 }}
               >
                 <span>Restart</span>
@@ -185,14 +190,14 @@ export const App = () => {
                     [JSON.stringify(circuitJson, null, 2)],
                     {
                       type: "application/json",
-                    },
-                  )
-                  const url = URL.createObjectURL(blob)
-                  const a = document.createElement("a")
-                  a.href = url
-                  a.download = "circuit.json"
-                  a.click()
-                  URL.revokeObjectURL(url)
+                    }
+                  );
+                  const url = URL.createObjectURL(blob);
+                  const a = document.createElement("a");
+                  a.href = url;
+                  a.download = "circuit.json";
+                  a.click();
+                  URL.revokeObjectURL(url);
                 }}
               >
                 <span>Download Circuit JSON</span>
@@ -204,8 +209,8 @@ export const App = () => {
                 type="button"
                 className="bg-purple-500 inline-flex items-center text-white p-2 rounded-md"
                 onClick={async () => {
-                  const url = await createSnippetUrl(tscircuitCode, "package")
-                  window.open(url, "_blank")
+                  const url = await createSnippetUrl(tscircuitCode, "package");
+                  window.open(url, "_blank");
                 }}
               >
                 <span>Open on Snippets</span>
@@ -260,5 +265,5 @@ export const App = () => {
         </div>
       </div>
     </div>
-  )
-}
+  );
+};


### PR DESCRIPTION
- Add Zod schemas for kicad_sym file structure including pins, properties, and symbol definitions
- Implement parseKicadSymToKicadJson parser for kicad_sym files
- Create convertKicadSymToSchematicInfo to extract schPortArrangement and pinLabels from symbol data
- Add parseKicadFilesToCircuitJson to handle both kicad_mod and kicad_sym files together
- Update convertKicadJsonToTsCircuitSoup to accept optional kicad_sym data and enhance schematic_component with port arrangement and pin labels
- Modify App.tsx to process kicad_sym files when available
- Add comprehensive tests for kicad_sym parsing and conversion functionality
- Export new functions in main index.ts

This enables the schematic view to display proper port arrangements and pin labels when both kicad_mod and kicad_sym files are provided, significantly improving the schematic representation of components.